### PR TITLE
fix: https repository url (unblock 2.0 publish)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@automatons/tools",
   "version": "1.0.218",
-  "repository": "git@github.com:openapi-automatons/tools.git",
+  "repository": "https://github.com/openapi-automatons/tools.git",
   "author": "tanmen <yt.prog@gmail.com>",
   "license": "MIT",
   "packageManager": "yarn@1.22.22",


### PR DESCRIPTION
## Problem
semantic-release failed on `main`: `git ls-remote git@github.com:... Permission denied (publickey)`. The `repository` field is an SSH URL, so semantic-release performs git operations over SSH, which has no key in CI.

## Fix
Use the HTTPS repository URL. semantic-release then uses HTTPS + the GitHub token (public repo `ls-remote` needs no auth; the release commit/tag push uses the token).