### PR TITLE
docs: note ESM-only / Node >= 22 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 ## What @automatons/tools
 This is utils for openapi-automatons.
 Only use openapi-automatons.
+
+Since v2 this package is **ESM-only** and requires **Node.js >= 22**.


### PR DESCRIPTION
Document that v2 is ESM-only and requires Node.js >= 22.