### PR TITLE
feat: add anyOf schema type and OpenAPI 3.2 server name

### DIFF
--- a/src/types/openapi.ts
+++ b/src/types/openapi.ts
@@ -34,6 +34,7 @@ export interface OpenapiInfoLicense {
 
 export interface OpenapiServer {
   url: string;
+  name?: string;
   'x-name'?: string;
   description?: string;
   variables?: OpenapiMap<OpenapiServerVariable>;
@@ -199,6 +200,7 @@ export type OpenapiSchema = OpenapiSchemaString
   | OpenapiSchemaArray
   | OpenapiSchemaAllOf
   | OpenapiSchemaOneOf
+  | OpenapiSchemaAnyOf
   | OpenapiSchemaReference;
 
 export type OpenapiSchemaReference = OpenapiReference & OpenapiSchemaCommon;
@@ -265,6 +267,16 @@ export interface OpenapiSchemaAllOf extends OpenapiSchemaCommon {
 
 export interface OpenapiSchemaOneOf extends OpenapiSchemaCommon {
   oneOf: OpenapiSchema[];
+  discriminator?: {
+    propertyName: string;
+    mapping?: {
+      [key: string]: string;
+    }
+  };
+}
+
+export interface OpenapiSchemaAnyOf extends OpenapiSchemaCommon {
+  anyOf: OpenapiSchema[];
   discriminator?: {
     propertyName: string;
     mapping?: {

--- a/src/utils/__tests__/schema.test.ts
+++ b/src/utils/__tests__/schema.test.ts
@@ -5,6 +5,7 @@ import {
   isSchemaBoolean,
   isSchemaInteger,
   isSchemaNumber,
+  isSchemaAnyOf,
   isSchemaObject,
   isSchemaOneOf,
   isSchemaRef,
@@ -43,6 +44,10 @@ it('should be detect allOf', () => {
 
 it('should be detect oneOf', () => {
   expect(isSchemaOneOf({oneOf: []})).toBeTruthy();
+});
+
+it('should be detect anyOf', () => {
+  expect(isSchemaAnyOf({anyOf: []})).toBeTruthy();
 });
 
 it('should be detect ref', () => {

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -5,6 +5,7 @@ import {
   OpenapiSchemaBoolean,
   OpenapiSchemaInteger,
   OpenapiSchemaNumber,
+  OpenapiSchemaAnyOf,
   OpenapiSchemaObject,
   OpenapiSchemaOneOf,
   OpenapiSchemaReference,
@@ -29,5 +30,7 @@ export const isSchemaAllOf =
   (type: OpenapiSchema): type is OpenapiSchemaAllOf => Object.hasOwn(type, 'allOf');
 export const isSchemaOneOf =
   (type: OpenapiSchema): type is OpenapiSchemaOneOf => Object.hasOwn(type, 'oneOf');
+export const isSchemaAnyOf =
+  (type: OpenapiSchema): type is OpenapiSchemaAnyOf => Object.hasOwn(type, 'anyOf');
 export const isSchemaRef =
   (type: OpenapiSchema): type is OpenapiSchemaReference => Object.hasOwn(type, '$ref');


### PR DESCRIPTION
Adds `OpenapiSchemaAnyOf` to the `OpenapiSchema` union with an `isSchemaAnyOf` guard, and adds the standard `name` field (OpenAPI 3.2) to `OpenapiServer`. Both are additive and used by the parser to support `anyOf` schemas and 3.2 server names.