### PR TITLE
feat: support OpenAPI 3.2 query method, additionalOperations, and querystring

### DIFF
--- a/src/types/http.ts
+++ b/src/types/http.ts
@@ -1,1 +1,1 @@
-export type Method = 'get' | 'put' | 'post' | 'delete' | 'options' | 'head' | 'patch' | 'trace';
+export type Method = 'get' | 'put' | 'post' | 'delete' | 'options' | 'head' | 'patch' | 'trace' | 'query';

--- a/src/types/openapi.ts
+++ b/src/types/openapi.ts
@@ -71,12 +71,15 @@ export interface OpenapiPath {
   head?: OpenapiPathOperation;
   patch?: OpenapiPathOperation;
   trace?: OpenapiPathOperation;
+  query?: OpenapiPathOperation;
+  additionalOperations?: OpenapiMap<OpenapiPathOperation>;
   servers?: OpenapiServer[];
   parameters?: OpenapiParameter[];
 }
 
 export type OpenapiParameter = OpenapiParameterPath
   | OpenapiParameterQuery
+  | OpenapiParameterQueryString
   | OpenapiParameterHeader
   | OpenapiParameterCookie
   | OpenapiReference;
@@ -114,6 +117,14 @@ export type OpenapiParameterCookie = {
   style: 'form';
   required?: boolean;
 } & OpenapiParameterCommon;
+
+export type OpenapiParameterQueryString = {
+  in: 'querystring';
+  name: string;
+  description?: string;
+  required?: boolean;
+  content: OpenapiMap<OpenapiPathMedia>;
+};
 
 export interface OpenapiPathOperation extends OpenapiPathCommon {
   operationId: string;

--- a/src/utils/parameter.ts
+++ b/src/utils/parameter.ts
@@ -5,6 +5,7 @@ import {
   OpenapiParameterHeader,
   OpenapiParameterPath,
   OpenapiParameterQuery,
+  OpenapiParameterQueryString,
   OpenapiPathMedia,
   OpenapiSchema,
 } from '../types';
@@ -20,6 +21,8 @@ export const isPathParam =
   (param: OpenapiParameter): param is OpenapiParameterPath => !isRef(param) && param.in === 'path';
 export const isQueryParam =
   (param: OpenapiParameter): param is OpenapiParameterQuery => !isRef(param) && param.in === 'query';
+export const isQueryStringParam =
+  (param: OpenapiParameter): param is OpenapiParameterQueryString => !isRef(param) && param.in === 'querystring';
 export const isHeaderParam =
   (param: OpenapiParameter): param is OpenapiParameterHeader => !isRef(param) && param.in === 'header';
 export const isCookieParam =

--- a/src/values/http.ts
+++ b/src/values/http.ts
@@ -1,3 +1,3 @@
 import {Method} from '../types';
 
-export const HTTP_METHODS: Method[] = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
+export const HTTP_METHODS: Method[] = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace', 'query'];


### PR DESCRIPTION
Adds the 3.2 `query` HTTP method and `additionalOperations` map to `OpenapiPath`, and the `querystring` parameter location (`OpenapiParameterQueryString` + `isQueryStringParam` guard). All additive; consumed by the parser/clients.